### PR TITLE
Why silly skirtlenecks can't be taken?

### DIFF
--- a/modular_te/code/modules/client/loadout/uniform.dm
+++ b/modular_te/code/modules/client/loadout/uniform.dm
@@ -1,0 +1,4 @@
+/datum/gear/skirtleneck
+	name = "Tactitool Skirtleneck"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/syndicate/cosmetic

--- a/modular_te/code/modules/clothing/under/syndicate.dm
+++ b/modular_te/code/modules/clothing/under/syndicate.dm
@@ -1,9 +1,5 @@
 /obj/item/clothing/under/syndicate/cosmetic/skirt
 	name = "tacticool skirtleneck"
-	desc = "Just looking at it makes you want to buy an SKS, go into the woods, and -operate-."
 	icon_state = "tactifool_skirt"
-	item_state = "bl_suit"
-	has_sensor = TRUE
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 0)
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON

--- a/modular_te/code/modules/clothing/under/syndicate.dm
+++ b/modular_te/code/modules/clothing/under/syndicate.dm
@@ -1,0 +1,9 @@
+/obj/item/clothing/under/syndicate/cosmetic/skirt
+	name = "tacticool skirtleneck"
+	desc = "Just looking at it makes you want to buy an SKS, go into the woods, and -operate-."
+	icon_state = "tactifool_skirt"
+	item_state = "bl_suit"
+	has_sensor = TRUE
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 0)
+	fitted = FEMALE_UNIFORM_TOP
+	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4286,4 +4286,6 @@
 #include "modular_skyrat\modules\horrorform\code\modules\mob\hostile\true_changeling.dm"
 #include "modular_skyrat\tools\Redirector\textprocs.dm"
 #include "modular_te\code\game\objects\items\phones.dm"
+#include "modular_te\code\modules\client\loadout\uniform.dm"
+#include "modular_te\code\modules\clothing\under\syndicate.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turtlenecks can be picked on the loadout, why the hell skirts are left out!?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The silly tacticool is appreciated.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the "cosmetic tacticool skirtleneck", takes the same stats of the regular one.
add: Added the "cosmetic tacticool skirtleneck" to the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
